### PR TITLE
fix snippet warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 *.vsix
 vsc-extension-quickstart.md
-testing.*
+/.idea/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,16 +3,17 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
+  "version": "0.2.0",
     "configurations": [
-        {
-            "name": "Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ]
-        }
+      {
+        "name": "Extension",
+        "type": "extensionHost",
+        "request": "launch",
+        "runtimeExecutable": "${execPath}",
+        "args": [
+          "examples",
+          "--extensionDevelopmentPath=${workspaceFolder}"
+        ]
+      }
     ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,3 +2,4 @@
 .vscode-test/**
 .gitignore
 vsc-extension-quickstart.md
+examples/**

--- a/examples/testing.html
+++ b/examples/testing.html
@@ -1,0 +1,10 @@
+{% extends %}
+<div> whatever</div>
+<script amp-template>{{ works_fine }}</script>
+{{ does_not('work fine') }}
+{{ inline_css('inline.css') }}
+<foobar>{{ inline_css('inline.css') }}</foobar>
+<div>"whatever"{{ thing }}</div>
+<div>
+  whatever
+</div>

--- a/examples/testing.jinja
+++ b/examples/testing.jinja
@@ -1,0 +1,27 @@
+{% extends 'whatever.jinja' %}
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <title>Hello, AMPs</title>
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>{{ inline_css('amp-boilerplate.css') }}</style>
+    <noscript>
+      <style amp-boilerplate>body {-webkit-animation: none;-moz-animation: none; -ms-animation: none; animation: none}</style>
+    </noscript>
+    <style amp-custom>{{ inline_css('inline.css') }}</style>
+    <foobar>{{ (4 * 7)|int }}</foobar>
+  </head>
+
+  <body>
+  {% if foo == bar %}
+    {% block body %}{% endblock %}
+    {% for x in foobar %}
+     {{ for}}
+    {% endfor %}
+
+    {{ inline_css('inline.css') }}
+  </body>
+</html>

--- a/examples/testing.md
+++ b/examples/testing.md
@@ -1,0 +1,6 @@
+# whatever
+
+{% for x in whatever %}
+{{ whatever }}
+{% endfor %}
+

--- a/examples/testing.yaml
+++ b/examples/testing.yaml
@@ -1,0 +1,14 @@
+{% if grains['os'] != 'FreeBSD' %}
+tcsh:
+    pkg:
+        - installed
+{% endif %}
+
+motd:
+  file.managed:
+    {% if grains['os'] == 'FreeBSD' %}
+    - name: /etc/motd
+    {% elif grains['os'] == 'Debian' %}
+    - name: /etc/motd.tail
+    {% endif %}
+    - source: salt://motd

--- a/snippets/django-snippets.json
+++ b/snippets/django-snippets.json
@@ -77,7 +77,7 @@
     "prefix": "lipsum",
     "description": "Generates some lorem ipsum for the template",
     "body": [
-      "{{ lipsum(${how_many_paragraphs}) }}"
+      "{{ lipsum(${1:how_many_paragraphs}) }}"
     ]
   },
   "Super": {
@@ -100,15 +100,15 @@
     "prefix": "url",
     "description": "URL tag",
     "body": [
-      "{{ url('${some-url-name}', ${arg}) }}"
+      "{{ url('${1:some-url-name}', ${2:arg}) }}"
     ]
   },
   "With": {
     "prefix": "with",
     "description": "With block",
     "body": [
-      "{% with ${local_var}=${context_var} %}",
-      "$1",
+      "{% with ${1:local_var}=${2:context_var} %}",
+      "$3",
       "{% endwith %}"
     ]
   },


### PR DESCRIPTION
Fix warning:

```
[samuelcolvin.jinjahtml]: One or more snippets from the extension 'jinjahtml' 
very likely confuse snippet-variables and snippet-placeholders 
(see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)
```