### PR TITLE
Add Jinja + Python support.

### DIFF
--- a/examples/testing.py.j2
+++ b/examples/testing.py.j2
@@ -1,0 +1,10 @@
+from X import Y
+
+class Foo:
+    def bar(self, y: Y) -> None:
+        return {{ variable }}
+
+    {% for method in methods -%}
+    def {{ method.name }}(self):
+        return {{ method.return_value }}
+    {% endfor -%}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
         "configuration": "./language-configuration.json"
       },
       {
+        "id": "jinja-py",
+        "aliases": ["Jinja Python", "jinja-py"],
+        "extensions": ["py.j2", "py.jinja2"],
+        "configuration": "./language-configuration.json"
+      },
+      {
         "id": "jinja-rb",
         "aliases": ["Jinja Ruby", "jinja-rb"],
         "extensions": ["rb.j2", "rbw.j2", "rb.jinja2", "rbw.jinja2"],
@@ -100,6 +106,11 @@
         "language": "jinja-md",
         "scopeName": "text.html.markdown.jinja",
         "path": "./syntaxes/jinja-md.tmLanguage.json"
+      },
+      {
+        "language": "jinja-py",
+        "scopeName": "text.python.jinja",
+        "path": "./syntaxes/jinja-python.tmLanguage.json"
       },
       {
         "language": "jinja-rb",

--- a/syntaxes/jinja-python.tmLanguage.json
+++ b/syntaxes/jinja-python.tmLanguage.json
@@ -1,6 +1,6 @@
 {
     "name": "jinja-python",
-    "scopeName": "text.python.jinja",
+    "scopeName": "source.python.jinja",
     "comment": "Jinja Python Templates",
     "patterns": [
       {

--- a/syntaxes/jinja-python.tmLanguage.json
+++ b/syntaxes/jinja-python.tmLanguage.json
@@ -1,0 +1,13 @@
+{
+    "name": "jinja-python",
+    "scopeName": "text.python.jinja",
+    "comment": "Jinja Python Templates",
+    "patterns": [
+      {
+        "include": "source.jinja"
+      },
+      {
+        "include": "source.python"
+      }
+    ]
+  }


### PR DESCRIPTION
This commit adds a Jinja / Python permutation, triggered by `*.py.j2` or `*.py.jinja2`, to match the other permutations.