### PR TITLE
add JavaScript support

### DIFF
--- a/examples/testing.js.j2
+++ b/examples/testing.js.j2
@@ -1,0 +1,10 @@
+class Immutable{{ name[0]|upper }}{{ name[1:] }} {
+    constructor({{ properties|join(", ") }}) {
+        {% for prop in properties -%}
+        Object.defineProperty(this, "{{ prop }}", {
+            "value": {{ prop }},
+            "writable": false,
+        });
+        {%- endfor %}
+    }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,12 @@
         "configuration": "./language-configuration.json"
       },
       {
+        "id": "jinja-js",
+        "aliases": ["Jinja JavaScript", "Jinja JS", "jinja-js"],
+        "extensions": ["js.j2", "js.jinja2"],
+        "configuration": "./language-configuration.json"
+      },
+      {
         "id": "jinja-yaml",
         "aliases": ["Jinja YAML", "jinja-yaml"],
         "extensions": [".yml.j2", ".yaml.j2", ".sls"],
@@ -105,6 +111,11 @@
         "language": "jinja-rb",
         "scopeName": "text.ruby.jinja",
         "path": "./syntaxes/jinja-ruby.tmLanguage.json"
+      },
+      {
+        "language": "jinja-js",
+        "scopeName": "source.js.jinja",
+        "path": "./syntaxes/jinja-js.tmLanguage.json"
       },
       {
         "language": "jinja-yaml",

--- a/syntaxes/jinja-js.tmLanguage.json
+++ b/syntaxes/jinja-js.tmLanguage.json
@@ -1,0 +1,13 @@
+{
+  "name": "jinja-js",
+  "scopeName": "source.js.jinja",
+  "comment": "Jinja JavaScript Templates",
+  "patterns": [
+    {
+      "include": "source.jinja"
+    },
+    {
+      "include": "source.js"
+    }
+  ]
+}


### PR DESCRIPTION
Note this doesn't seem to highlight Jinja2 tags inside of strings or lists but not sure if tmLanguage is even robust enough for that (without rewriting `JavaScript.tmLanguage.json` to include it).

I checked the SQL one and it has the same problem within quoted strings so I guess that's fine/expected.