### PR TITLE
Add .env.jinja extensions to jinja-shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "extensions": [
           ".sh.j2", ".bash.j2", ".bashrc.j2", ".bash_aliases.j2", ".bash_profile.j2", ".bash_login.j2", ".ebuild.j2",
           ".install.j2", ".profile.j2", ".bash_logout.j2", ".zsh.j2", ".zshrc.j2", ".zprofile.j2", ".zlogin.j2",
-          ".zlogout.j2", ".zshenv.j2", ".zsh-theme.j2", ".ksh.j2"
+          ".zlogout.j2", ".zshenv.j2", ".zsh-theme.j2", ".ksh.j2", ".env.jinja", ".env.j2", ".env.jinja2"
         ],
         "configuration": "./language-configuration.json"
       },


### PR DESCRIPTION
Fix #47.