### PR TITLE
added autoClosingPairs for default Jinja2 syntax

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -11,11 +11,13 @@
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
-        ["{", "}"],
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
-        ["'", "'"]
+        ["'", "'"],
+        ["{#", "#}"],
+        ["{{", "}}"],
+        ["{%", "%}"]
     ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [


### PR DESCRIPTION
Hi, this solves issue #69.

Just added autoClodingPairs for Jinja2's default syntax:

{%, {# and {{