### PR TITLE
recognize include file templates for C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Default file associations: `.link.j2`, `.link.jinja`, `.link.jinja2`, `.netdev.j
 
 Jinja C++ templates: system name `jinja-cpp`.
 
-Default file associations: `.cpp.jinja`, `.cpp.jinja2` and `.cpp.j2`.
+Default file associations: `.cpp.jinja`, `.cpp.jinja2`,`.cpp.j2`,`.h.jinja`, `.h.jinja2`, and `.h.j2`.
 
 ## Extra File Associations
 

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
       {
         "id": "jinja-cpp",
         "aliases": ["Jinja C++", "jinja-cpp"],
-        "extensions": [".cpp.j2", ".cpp.jinja", ".cpp.jinja2"],
+        "extensions": [".cpp.j2", ".cpp.jinja", ".cpp.jinja2", ".h.j2", ".h.jinja", ".h.jinja2"],
         "configuration": "./language-configuration.json"
       }
     ],


### PR DESCRIPTION
Thanks for a very helpful extension!  

Right now, the extension doesn't recognize C++ include files by default. This adds .h.* files to the list...