### PR TITLE
Added support for nested comments

### DIFF
--- a/syntaxes/jinja.tmLanguage.json
+++ b/syntaxes/jinja.tmLanguage.json
@@ -22,14 +22,7 @@
       "name": "comment.block.jinja.raw"
     },
     {
-      "begin": "{#-?",
-      "captures": [
-        {
-          "name": "entity.other.jinja.delimiter.comment"
-        }
-      ],
-      "end": "-?#}",
-      "name": "comment.block.jinja"
+      "include": "#comments"
     },
     {
       "begin": "{{-?",
@@ -63,6 +56,21 @@
     }
   ],
   "repository": {
+    "comments": {
+      "begin": "{#-?",
+      "captures": [
+        {
+          "name": "entity.other.jinja.delimiter.comment"
+        }
+      ],
+      "end": "-?#}",
+      "name": "comment.block.jinja",
+      "patterns": [
+        {
+          "include": "#comments"
+        }
+      ]
+    },
     "escaped_char": {
       "match": "\\\\x[0-9A-F]{2}",
       "name": "constant.character.escape.hex.jinja"


### PR DESCRIPTION
As the title says, I've added support for nested comments.

[Askama]: https://github.com/djc/askama
[rust]: https://doc.rust-lang.org/reference/comments.html

|Before|After|
|---|---|
| ![before] | ![after] |

[before]: https://user-images.githubusercontent.com/17464404/102712876-73dfc480-42c4-11eb-9c2b-c3f6b2493f14.png
[after]: https://user-images.githubusercontent.com/17464404/102712862-61fe2180-42c4-11eb-9418-e15baccb4f5b.png

Support for nested comments were added to [Askama] the other day, to be on par with Rust which also [supports nested comments][rust].

Disclaimer: I'm a co-maintainer of Askama.