### PR TITLE
Fix wrong default Java file associations in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ Default file associations: `.link.j2`, `.link.jinja`, `.link.jinja2`, `.netdev.j
 
 Jinja C++ templates: system name `jinja-cpp`.
 
-Default file associations: `.cpp.jinja`, `.cpp.jinja2`,`.cpp.j2`,`.h.jinja`, `.h.jinja2`, and `.h.j2`.
+Default file associations: `.cpp.jinja`, `.cpp.jinja2`, `.cpp.j2`, `.h.jinja`, `.h.jinja2`, and `.h.j2`.
 
 ### Jinja Java
 
 Jinja Java templates: system name `jinja-java`.
 
-Default file associations: `..jinja`, `.cpp.jinja2` and `.cpp.j2`.
+Default file associations: `.java.j2`, `.java.jinja`, and `.java.jinja2`.
 
 ## Extra File Associations
 


### PR DESCRIPTION
Before this commit, README contained the wrong default file associations for Java.
This commit fixes the documentation to the correct associations.