### PR TITLE
Create jinja-php.tmLanguage.json (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,12 @@
         "aliases": ["Jinja Java"],
         "extensions": [".java.j2", ".java.jinja", ".java.jinja2"],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "jinja-php",
+        "aliases": ["Jinja PHP"],
+        "extensions": [".php.j2", ".php.jinja", ".php.jinja2"],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -291,6 +297,11 @@
         "language": "jinja-java",
         "scopeName": "source.java.jinja",
         "path": "./syntaxes/jinja-java.tmLanguage.json"
+      },
+      {
+        "language": "jinja-php",
+        "scopeName": "source.php.jinja",
+        "path": "./syntaxes/jinja-php.tmLanguage.json"
       }
     ],
     "snippets": [

--- a/syntaxes/jinja-php.tmLanguage.json
+++ b/syntaxes/jinja-php.tmLanguage.json
@@ -1,0 +1,13 @@
+{
+  "name": "jinja-php",
+  "scopeName": "source.php.jinja",
+  "comment": "Jinja PHP Templates",
+  "patterns": [
+    {
+      "include": "source.jinja"
+    },
+    {
+      "include": "source.php"
+    }
+  ]
+}


### PR DESCRIPTION
Hi Samuel,

I added php syntax highlighting to your plugin. I think, I did everything that is required to make it work.

Example screenshot:

![grafik](https://user-images.githubusercontent.com/3439311/153606605-0e27cb6e-7d32-4af4-b9e8-362e605d6d8f.png)

Steps done:

* Create jinja-php.tmLanguage.json

* Update package.json (grammar and language config)

Would be happy to contribute to your plugin. If anything is missing or problematic, let me know :)