### PR TITLE
Yaml comments

### DIFF
--- a/language-configuration-yaml.json
+++ b/language-configuration-yaml.json
@@ -1,0 +1,41 @@
+{
+  "comments": {
+    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+    "lineComment": "#"
+  },
+  // symbols used as brackets
+  "brackets": [
+    ["{#", "#}"],
+    ["{%", "%}"],
+    ["{{", "}}"],
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    ["@/", "/"],
+    ["{#", "#}"],
+    ["{%", "%}"],
+    ["{{", "}}"],
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // symbols that that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "folding": {
+    "markers": {
+      "start": "{%\\s*(block|filter|for|if|macro|raw)",
+      "end": "{%\\s*end(block|filter|for|if|macro|raw)\\s*%}"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
           ".yaml.jinja",
           ".sls"
         ],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration-yaml.json"
       },
       {
         "id": "jinja-toml",


### PR DESCRIPTION
Fixes https://github.com/samuelcolvin/jinjahtml-vscode/issues/70

`ctrl+/` toggles Yaml's comment `#`, instead of Jinja's block comment `{# #}` when Jinja Yaml is selected

I created a new `language-configuration-yaml.json` for Yaml