### PR TITLE
Enable VSCode HTML Lanaguage Participants (solves #109)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
   "devDependencies": {
     "prettier": "2.7.1"
   },
+  "extensionDependencies": [
+    "vscode.html-language-features"
+  ],
   "contributes": {
     "languages": [
       {
@@ -488,6 +491,12 @@
           ".rs.jinja2"
         ],
         "configuration": "./language-configuration.json"
+      }
+    ],
+    "htmlLanguageParticipants": [
+      {
+        "languageId": "jinja-html",
+        "autoInsert": true
       }
     ],
     "grammars": [


### PR DESCRIPTION
This adds support for the HTML Language Participants feature.

One issue I've been bumping into is that `vscode.html-language-features` doesn't seem to activate by default so you need to first change the language mode to HTML, then back to Jinja HTML. This loads `vscode.html-language-features` and then allows for this extension to load. If anyone has any ideas how to solve this, I'd love to hear it! It could also maybe be a bug/ unexpected behavior with VSCode?