### PR TITLE
Add hcl file endings for terraform/HashiCorp configuration language

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ Jinja cython templates: system name `jinja-cy`.
 
 Default file associations: `.pyx.j2`, `.pyx.jinja`, `.pyx.jinja2`, `.pxd.j2`, `.pxd.jinja`, `.pxd.jinja2`, `.pxi.j2`, `.pxi.jinja` and `.pxi.jinja2`.
 
-### Jinja Terraform
+### Jinja Terraform / HashiCorp configuration language
 
 Jinja Terraform templates: system name `jinja-terraform`.
 
-Default file associations: `.tf.j2`, `.tf.jinja`, `.tf.jinja2`, `.tfvars.j2`, `.tfvars.jinja`, and `.tfvars.jinja2`.
+Default file associations: `.tf.j2`, `.tf.jinja`, `.tf.jinja2`, `.tfvars.j2`, `.tfvars.jinja`, `.tfvars.jinja2`, `.hcl.j2`, `.hcl.jinja` and `.hcl.jinja2`.
 
 ### Jinja Nginx
 

--- a/package.json
+++ b/package.json
@@ -326,7 +326,11 @@
         "id": "jinja-terraform",
         "aliases": [
           "Jinja Terraform",
-          "jinja-terraform"
+          "jinja-terraform",
+          "Jinja-HCL",
+          "jinja-hcl",
+          "Jinja-Hashicorp",
+          "jinja-hashicorp"
         ],
         "extensions": [
           ".tf.j2",
@@ -334,7 +338,10 @@
           ".tf.jinja2",
           ".tfvars.j2",
           ".tfvars.jinja",
-          ".tfvars.jinja2"
+          ".tfvars.jinja2",
+          ".hcl.j2",
+          ".hcl.jinja",
+          ".hcl.jinja2"
         ],
         "configuration": "./language-configuration.json"
       },


### PR DESCRIPTION
Terraform is a syntax defined as HCL, as described by HashiCorp here: https://www.terraform.io/language/syntax/configuration

This pull request, adds HCL file endings to the terraform configuration, and mentions HashiCorp configuration language in the README.

I thought about renaming the whole terraform files to hcl since this is a superset of terraform, but I think just adding the file endings is the safer approach and less likely to break stuff.

Fixes #104 