### PR TITLE
Support `.yml.jinja`/`.yaml.jinja` file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Default file associations: `.md.jinja`, `.md.jinja2` and `.md.j2`.
 
 Jinja YAML (sls) templates: system name `jinja-yaml`.
 
-Default file associations: `.yml.j2`, `.yaml.j2` and `.sls`.
+Default file associations: `.yml.j2`, `.yaml.j2`, `.yaml.jinja`, `.yml.jinja`, and `.sls`.
 
 ### Jinja TOML
 

--- a/syntaxes/jinja-yaml.tmLanguage.json
+++ b/syntaxes/jinja-yaml.tmLanguage.json
@@ -2,7 +2,7 @@
   "name": "jinja-yaml",
   "scopeName": "text.yaml.jinja",
   "comment": "Jinja YAML Templates",
-  "fileTypes": ["yml.j2", "yaml.j2", "sls"],
+  "fileTypes": ["yml.j2", "yaml.j2", "yml.jinja", "yaml.jinja", "sls"],
   "firstLineMatch": "^{% extends [\"'][^\"']+[\"'] %}",
   "patterns": [
     {


### PR DESCRIPTION
According to jina, .jinja is the suggested template file extension: https://jinja.palletsprojects.com/en/2.11.x/templates/#template-file-extension

Fixes #125

Signed-off-by: Craig Andrews <candrews@integralblue.com>