### PR TITLE
Add support for named block end-tags

### DIFF
--- a/language-configuration-latex.json
+++ b/language-configuration-latex.json
@@ -37,7 +37,7 @@
   "folding": {
     "markers": {
       "start": "\\(\\(\\*\\s*(block|filter|for|if|macro|raw)",
-      "end": "\\(\\(\\*\\s*end(block|filter|for|if|macro|raw)\\s*\\*\\)\\)"
+      "end": "\\(\\(\\*\\s*end(block\\s+[a-zA-Z_][a-zA-Z0-9_]*|filter|for|if|macro|raw)\\s*\\*\\)\\)"
     }
   }
 }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -35,7 +35,7 @@
   "folding": {
     "markers": {
       "start": "{%\\s*(block|filter|for|if|macro|raw)",
-      "end": "{%\\s*end(block|filter|for|if|macro|raw)\\s*%}"
+      "end": "{%\\s*end(block\\s+[a-zA-Z_][a-zA-Z0-9_]*|filter|for|if|macro|raw)\\s*%}"
     }
   }
 }

--- a/syntaxes/jinja-latex.tmLanguage.json
+++ b/syntaxes/jinja-latex.tmLanguage.json
@@ -4,7 +4,7 @@
   "comment": "Jinja Latex Templates",
   "firstLineMatch": "^(\\(\\(\\* extends [\"'][^\"']+[\"'] \\*\\)\\)",
   "foldingStartMarker": "(\\(\\(\\*\\s*(block|filter|for|if|macro|raw))",
-  "foldingStopMarker": "(\\(\\(\\*\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*\\*\\)\\))",
+  "foldingStopMarker": "(\\(\\(\\*\\s*(endblock\\s+[a-zA-Z_][a-zA-Z0-9_]*|endfilter|endfor|endif|endmacro|endraw)\\s*\\*\\)\\))",
   "patterns": [
     {
       "include": "text.tex.latex"

--- a/syntaxes/jinja-md.tmLanguage.json
+++ b/syntaxes/jinja-md.tmLanguage.json
@@ -4,7 +4,7 @@
   "comment": "Jinja Markdown Templates",
   "firstLineMatch": "^{% extends [\"'][^\"']+[\"'] %}",
   "foldingStartMarker": "(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))",
-  "foldingStopMarker": "(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})",
+  "foldingStopMarker": "(</(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock\\s+[a-zA-Z_][a-zA-Z0-9_]*|endfilter|endfor|endif|endmacro|endraw)\\s*%})",
   "patterns": [
     {
       "include": "source.jinja"

--- a/syntaxes/jinja.tmLanguage.json
+++ b/syntaxes/jinja.tmLanguage.json
@@ -3,7 +3,7 @@
   "scopeName": "source.jinja",
   "comment": "Jinja Templates",
   "foldingStartMarker": "({%\\s*(block|filter|for|if|macro|raw))",
-  "foldingStopMarker": "({%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})",
+  "foldingStopMarker": "({%\\s*(endblock\\s+[a-zA-Z_][a-zA-Z0-9_]*|endfilter|endfor|endif|endmacro|endraw)\\s*%})",
   "patterns": [
     {
       "begin": "({%)\\s*(raw)\\s*(%})",


### PR DESCRIPTION
Jinja allows you to put the name of the block after the end tag for better readability: https://jinja.palletsprojects.com/en/latest/templates/#named-block-end-tags

This change adds regexs to allow for a name after `endblock`.  No checking is done to match the corresponding `block` and `endblock` names.