### PR TITLE
fix: wrong terraform scope name used

### DIFF
--- a/syntaxes/jinja-terraform.tmLanguage.json
+++ b/syntaxes/jinja-terraform.tmLanguage.json
@@ -7,7 +7,7 @@
       "include": "source.jinja"
     },
     {
-      "include": "source.terraform"
+      "include": "source.hcl.terraform"
     }
   ]
 }


### PR DESCRIPTION
Correct scope name can be found here: https://github.com/hashicorp/syntax/blob/main/syntaxes/terraform.tmGrammar.json#L2