### PR TITLE
Add raw default file associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Introduces syntax highlighting into vscode for the following languages:
 
 Raw jinja templates: system name `jinja`.
 
-no file default associations.
+Default file associations: `.raw.jinja`, `.raw.jinja2`, `raw.j2`.
 
 ### Jinja HTML
 

--- a/package.json
+++ b/package.json
@@ -336,7 +336,11 @@
           "Jinja Raw",
           "jinja-raw"
         ],
-        "extensions": [],
+        "extensions": [
+          ".raw.j2",
+          ".raw.jinja",
+          ".raw.jinja2"
+        ],
         "configuration": "./language-configuration.json"
       },
       {


### PR DESCRIPTION
This PR adds default file extension associations for plain/raw Jinja files.

There is currently no way (without modifying VSCode settings) to associate a plaintext Jinja file with the Jinja language provided by this extension.

All `.j2`, `.jinja`, and `.jinja2` files without a known/specific type are mapped to HTML which will cause formatting issues on plaintext files.

This PR provides the ability to associate your files with Jinja without an inherited/sub language.