### PR TITLE
update language configuration

### DIFF
--- a/language-configuration-latex.json
+++ b/language-configuration-latex.json
@@ -1,12 +1,12 @@
 {
   "comments": {
     // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-    "blockComment": ["((#", "#))"]
+    "blockComment": ["((=", "=))"]
   },
   // symbols used as brackets
   "brackets": [
     ["((*", "*))"],
-    ["((#", "#))"],
+    ["((=", "=))"],
     ["(((", ")))"],
     ["((", "))"],
     ["(", ")"],
@@ -17,8 +17,11 @@
   "autoClosingPairs": [
     ["@/", "/"],
     ["((*", "*))"],
-    ["((#", "#))"],
+    ["((=", "=))"],
     ["(((", ")))"],
+    ["((* ", " *))"],
+    ["((= ", " =))"],
+    ["((( ", " )))"],
     ["((", "))"],
     ["(", ")"],
     ["{", "}"],
@@ -36,8 +39,8 @@
   ],
   "folding": {
     "markers": {
-      "start": "\\(\\(\\*\\s*(block|filter|for|if|macro|raw)",
-      "end": "\\(\\(\\*\\s*end(block|filter|for|if|macro|raw)\\s*\\*\\)\\)"
+      "start": "\\(\\(\\*[+-]?\\s*(block|filter|for|if|macro|raw)",
+      "end": "\\(\\(\\*[+-]?\\s*end(block|filter|for|if|macro|raw)\\s*[+-]?\\*\\)\\)"
     }
   }
 }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -18,6 +18,9 @@
     ["{#", "#}"],
     ["{%", "%}"],
     ["{{", "}}"],
+    ["{# ", " #}"],
+    ["{% ", " %}"],
+    ["{{ ", " }}"],
     ["{", "}"],
     ["[", "]"],
     ["(", ")"],
@@ -34,8 +37,8 @@
   ],
   "folding": {
     "markers": {
-      "start": "{%\\s*(block|filter|for|if|macro|raw)",
-      "end": "{%\\s*end(block|filter|for|if|macro|raw)\\s*%}"
+      "start": "{%[-+]?\\s*(block|filter|for|if|macro|raw)",
+      "end": "{%[-+]?\\s*end(block|filter|for|if|macro|raw)\\s*[-+]?%}"
     }
   }
 }

--- a/syntaxes/jinja-latex.tmLanguage.json
+++ b/syntaxes/jinja-latex.tmLanguage.json
@@ -26,13 +26,13 @@
       "name": "comment.block.jinja.raw"
     },
     {
-      "begin": "\\(\\(#-?",
+      "begin": "\\(\\(=-?",
       "captures": [
         {
           "name": "entity.other.jinja.delimiter.comment"
         }
       ],
-      "end": "-?#\\)\\)",
+      "end": "-?=\\)\\)",
       "name": "comment.block.jinja"
     },
     {


### PR DESCRIPTION
Hey, while working on a new language server for Jinja I encountered two small adjustments I think make the experience a bit better:
- The folding start/end should allow for the whitespace control characters aswell.
- I think it's worth adding the additional brackets with whitespace so that opening a statement with space is matches by a closing space, it makes for a much nicer editing experience in my opinion.

Also fixed the latex configuration to match what's said in the readme and seems to be the case in nbconvert

Would love your opinion on the language server as well - https://github.com/noamzaks/jinja-ls :)