### PR TITLE
Add onEnterRules for HTML tag and Jinja block auto-indent

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -42,12 +42,12 @@
     {
       "beforeText": "<(?!\\/)([_:\\w][_:\\w-.\\d]*)([^/>]*(?!\\/)>)[^<]*$",
       "afterText": "^</([_:\\w][_:\\w-.\\d]*)\\s*>",
-      "action": { "indent": "indentOutdent" }
+      "action": {"indent": "indentOutdent"}
     },
     {
       "beforeText": "\\{%\\s*(block|if|for|with|macro|call|filter|raw|autoescape)\\b.*%\\}\\s*$",
       "afterText": "^\\s*\\{%\\s*end\\w+\\b.*%\\}",
-      "action": { "indent": "indentOutdent" }
+      "action": {"indent": "indentOutdent"}
     }
-  ],
+  ]
 }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -37,5 +37,17 @@
       "start": "{%\\s*(block|filter|for|if|macro|raw)",
       "end": "{%\\s*end(block|filter|for|if|macro|raw)\\s*%}"
     }
-  }
+  },
+  "onEnterRules": [
+    {
+      "beforeText": "<(?!\\/)([_:\\w][_:\\w-.\\d]*)([^/>]*(?!\\/)>)[^<]*$",
+      "afterText": "^</([_:\\w][_:\\w-.\\d]*)\\s*>",
+      "action": { "indent": "indentOutdent" }
+    },
+    {
+      "beforeText": "\\{%\\s*(block|if|for|with|macro|call|filter|raw|autoescape)\\b.*%\\}\\s*$",
+      "afterText": "^\\s*\\{%\\s*end\\w+\\b.*%\\}",
+      "action": { "indent": "indentOutdent" }
+    }
+  ],
 }


### PR DESCRIPTION
Currently, pressing Enter between paired HTML tags (<div>|</div>) or Jinja blocks ({% block %}|{% endblock %}) doesn't auto-indent, unlike VS Code's built-in HTML mode.
This PR adds two onEnterRules to language-configuration.json:

One for HTML tags (matching VS Code's HTML behavior)
One for Jinja block constructs (block, if, for, with, macro, call, filter, raw, autoescape)

Tested locally in the Extension Development Host across both HTML and Jinja tag scenarios.