### PR TITLE
Fix linked tabstop causing duplicate typing in block snippet and others

### DIFF
--- a/snippets/django-snippets.json
+++ b/snippets/django-snippets.json
@@ -2,7 +2,7 @@
   "Comment": {
     "prefix": "comment",
     "description": "Comment block",
-    "body": ["{# $1", "\t$2", "#}"]
+    "body": ["{# $1", "\t$0", "#}"]
   },
   "var": {
     "prefix": "var",
@@ -27,17 +27,17 @@
   "For loop": {
     "prefix": "for",
     "description": "For loop",
-    "body": ["{% for $1 in $2 %}", "$3", "{% endfor %}"]
+    "body": ["{% for $1 in $2 %}", "\t$0", "{% endfor %}"]
   },
   "For-Else loop": {
     "prefix": "forelse",
     "description": "For-Else loop",
-    "body": ["{% for $1 in $2 %}", "$3", "{% else %}", "$4", "{% endfor %}"]
+    "body": ["{% for $1 in $2 %}", "\t$0", "{% else %}", "\t", "{% endfor %}"]
   },
   "If condition": {
     "prefix": "if",
     "description": "IF condition",
-    "body": ["{% if $1 %}", "$2", "{% else %}", "{% endif %}"]
+    "body": ["{% if $1 %}", "\t$0", "{% else %}", "\t","{% endif %}"]
   },
   "Include": {
     "prefix": "include",
@@ -57,7 +57,7 @@
   "Template Block": {
     "prefix": "block",
     "description": "Creates a block",
-    "body": ["{% block $1 %}", "$2", "{% endblock $1 %}"]
+    "body": ["{% block $1 %}", "\t$0", "{% endblock %}"]
   },
   "URL": {
     "prefix": "url",

--- a/snippets/django-snippets.json
+++ b/snippets/django-snippets.json
@@ -37,7 +37,7 @@
   "If condition": {
     "prefix": "if",
     "description": "IF condition",
-    "body": ["{% if $1 %}", "\t$0", "{% else %}", "\t","{% endif %}"]
+    "body": ["{% if $1 %}", "\t$0", "{% else %}", "\t", "{% endif %}"]
   },
   "Include": {
     "prefix": "include",


### PR DESCRIPTION
Several snippets used a numbered tabstop (e.g. `$2`) as their final stop, 
which kept the snippet session active after tabbing through.

This PR replaces the final tabstop in affected snippets with `$0`, which 
is VS Code's designated "exit snippet mode" tabstop. After landing on 
$0, the editor returns to normal mode immediately, so Enter/auto-indent 
behaves as expected.

Tested in the Extension Development Host: expanding the block and 
comment snippets, tabbing to the final stop, and other snippets like if, for, forelse.